### PR TITLE
Update dependencies for SS4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"php": ">=5.6.0",
 		"composer/installers": "~1.0",
-		"silverstripe/framework": "4.0.x-dev",
+		"silverstripe/framework": "~4.0",
 		"league/flysystem-aws-s3-v3": "^1.0"
 	},
 


### PR DESCRIPTION
The current version does not support the latest version of SS4.

Dependencies updated.